### PR TITLE
ecal protobuf variant changed to use callbacks

### DIFF
--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -276,7 +276,7 @@ if(PERFORMANCE_TEST_ICEORYX_ENABLED)
   list(APPEND sources src/communication_abstractions/iceoryx_communicator.hpp)
 endif()
 
-if(PERFORMANCE_TEST_ECAL_PROTO_ENABLED)
+if(PERFORMANCE_TEST_ECAL_RAW_ENABLED)
   list(APPEND sources src/communication_abstractions/ecal_raw_communicator.hpp)
 endif()
 

--- a/performance_test/msg/protobuf/Array16k.proto
+++ b/performance_test/msg/protobuf/Array16k.proto
@@ -1,13 +1,15 @@
 // Copyright 2022 Zhenshenglee, Inc.
-syntax = "proto2";
+
+syntax = "proto3";
 
 package performance_test.msg.__plugin__;
 
 message Array16k
 {
   // 16384/4
-  required int32 msg_array_size = 1 [default = 4096];
-  repeated uint32 array = 2;
-  required int64 time = 3;
-  required uint64 id = 4;
+  enum msg_array_size_e {MIN = 0; MAX = 4096;}
+  msg_array_size_e msg_array_size = 1;
+  repeated fixed32 array          = 2;
+  int64            time           = 3;
+  uint64           id             = 4;
 }

--- a/performance_test/msg/protobuf/Array1k.proto
+++ b/performance_test/msg/protobuf/Array1k.proto
@@ -1,13 +1,15 @@
 // Copyright 2022 Zhenshenglee, Inc.
-syntax = "proto2";
+
+syntax = "proto3";
 
 package performance_test.msg.__plugin__;
 
 message Array1k
 {
   // 1024/4
-  required int32 msg_array_size = 1 [default = 256];
-  repeated uint32 array = 2;
-  required int64 time = 3;
-  required uint64 id = 4;
+  enum msg_array_size_e {MIN = 0; MAX = 256;}
+  msg_array_size_e msg_array_size = 1;
+  repeated fixed32 array          = 2;
+  int64            time           = 3;
+  uint64           id             = 4;
 }

--- a/performance_test/msg/protobuf/Array1m.proto
+++ b/performance_test/msg/protobuf/Array1m.proto
@@ -1,13 +1,15 @@
 // Copyright 2022 Zhenshenglee, Inc.
-syntax = "proto2";
+
+syntax = "proto3";
 
 package performance_test.msg.__plugin__;
 
 message Array1m
 {
   // 1048576/4
-  required int32 msg_array_size = 1 [default = 262144];
-  repeated uint32 array = 2;
-  required int64 time = 3;
-  required uint64 id = 4;
+  enum msg_array_size_e {MIN = 0; MAX = 262144;}
+  msg_array_size_e msg_array_size = 1;
+  repeated fixed32 array          = 2;
+  int64            time           = 3;
+  uint64           id             = 4;
 }

--- a/performance_test/msg/protobuf/Array256k.proto
+++ b/performance_test/msg/protobuf/Array256k.proto
@@ -1,13 +1,15 @@
 // Copyright 2022 Zhenshenglee, Inc.
-syntax = "proto2";
+
+syntax = "proto3";
 
 package performance_test.msg.__plugin__;
 
 message Array256k
 {
   // 262144/4
-  required int32 msg_array_size = 1 [default = 65536];
-  repeated uint32 array = 2;
-  required int64 time = 3;
-  required uint64 id = 4;
+  enum msg_array_size_e {MIN = 0; MAX = 65536;}
+  msg_array_size_e msg_array_size = 1;
+  repeated fixed32 array          = 2;
+  int64            time           = 3;
+  uint64           id             = 4;
 }

--- a/performance_test/msg/protobuf/Array2m.proto
+++ b/performance_test/msg/protobuf/Array2m.proto
@@ -1,13 +1,15 @@
 // Copyright 2022 Zhenshenglee, Inc.
-syntax = "proto2";
+
+syntax = "proto3";
 
 package performance_test.msg.__plugin__;
 
 message Array2m
 {
   // 2097152/4
-  required int32 msg_array_size = 1 [default = 524288];
-  repeated uint32 array = 2;
-  required int64 time = 3;
-  required uint64 id = 4;
+  enum msg_array_size_e {MIN = 0; MAX = 524288;}
+  msg_array_size_e msg_array_size = 1;
+  repeated fixed32 array          = 2;
+  int64            time           = 3;
+  uint64           id             = 4;
 }

--- a/performance_test/msg/protobuf/Array32k.proto
+++ b/performance_test/msg/protobuf/Array32k.proto
@@ -1,13 +1,15 @@
 // Copyright 2022 Zhenshenglee, Inc.
-syntax = "proto2";
+
+syntax = "proto3";
 
 package performance_test.msg.__plugin__;
 
 message Array32k
 {
   // 32768/4
-  required int32 msg_array_size = 1 [default = 8192];
-  repeated uint32 array = 2;
-  required int64 time = 3;
-  required uint64 id = 4;
+  enum msg_array_size_e {MIN = 0; MAX = 8192;}
+  msg_array_size_e msg_array_size = 1;
+  repeated fixed32 array          = 2;
+  int64            time           = 3;
+  uint64           id             = 4;
 }

--- a/performance_test/msg/protobuf/Array4k.proto
+++ b/performance_test/msg/protobuf/Array4k.proto
@@ -1,13 +1,15 @@
 // Copyright 2022 Zhenshenglee, Inc.
-syntax = "proto2";
+
+syntax = "proto3";
 
 package performance_test.msg.__plugin__;
 
 message Array4k
 {
   // 4096/4
-  required int32 msg_array_size = 1 [default = 1024];
-  repeated uint32 array = 2;
-  required int64 time = 3;
-  required uint64 id = 4;
+  enum msg_array_size_e {MIN = 0; MAX = 1024;}
+  msg_array_size_e msg_array_size = 1;
+  repeated fixed32 array          = 2;
+  int64            time           = 3;
+  uint64           id             = 4;
 }

--- a/performance_test/msg/protobuf/Array4m.proto
+++ b/performance_test/msg/protobuf/Array4m.proto
@@ -1,13 +1,15 @@
 // Copyright 2022 Zhenshenglee, Inc.
-syntax = "proto2";
+
+syntax = "proto3";
 
 package performance_test.msg.__plugin__;
 
 message Array4m
 {
   // 4194304/4
-  required int32 msg_array_size = 1 [default = 1048576];
-  repeated uint32 array = 2;
-  required int64 time = 3;
-  required uint64 id = 4;
+  enum msg_array_size_e {MIN = 0; MAX = 1048576;}
+  msg_array_size_e msg_array_size = 1;
+  repeated fixed32 array          = 2;
+  int64            time           = 3;
+  uint64           id             = 4;
 }

--- a/performance_test/msg/protobuf/Array60k.proto
+++ b/performance_test/msg/protobuf/Array60k.proto
@@ -1,13 +1,15 @@
 // Copyright 2022 Zhenshenglee, Inc.
-syntax = "proto2";
+
+syntax = "proto3";
 
 package performance_test.msg.__plugin__;
 
 message Array60k
 {
   // 61440/4
-  required int32 msg_array_size = 1 [default = 15360];
-  repeated uint32 array = 2;
-  required int64 time = 3;
-  required uint64 id = 4;
+  enum msg_array_size_e {MIN = 0; MAX = 15360;}
+  msg_array_size_e msg_array_size = 1;
+  repeated fixed32 array          = 2;
+  int64            time           = 3;
+  uint64           id             = 4;
 }

--- a/performance_test/msg/protobuf/Array64k.proto
+++ b/performance_test/msg/protobuf/Array64k.proto
@@ -1,13 +1,15 @@
 // Copyright 2022 Zhenshenglee, Inc.
-syntax = "proto2";
+
+syntax = "proto3";
 
 package performance_test.msg.__plugin__;
 
 message Array64k
 {
   // 65536/4
-  required int32 msg_array_size = 1 [default = 16384];
-  repeated uint32 array = 2;
-  required int64 time = 3;
-  required uint64 id = 4;
+  enum msg_array_size_e {MIN = 0; MAX = 16384;}
+  msg_array_size_e msg_array_size = 1;
+  repeated fixed32 array          = 2;
+  int64            time           = 3;
+  uint64           id             = 4;
 }

--- a/performance_test/msg/protobuf/Array8m.proto
+++ b/performance_test/msg/protobuf/Array8m.proto
@@ -1,13 +1,15 @@
 // Copyright 2022 Zhenshenglee, Inc.
-syntax = "proto2";
+
+syntax = "proto3";
 
 package performance_test.msg.__plugin__;
 
 message Array8m
 {
   // 8388608/4
-  required int32 msg_array_size = 1 [default = 2097152];
-  repeated uint32 array = 2;
-  required int64 time = 3;
-  required uint64 id = 4;
+  enum msg_array_size_e {MIN = 0; MAX = 2097152;}
+  msg_array_size_e msg_array_size = 1;
+  repeated fixed32 array          = 2;
+  int64            time           = 3;
+  uint64           id             = 4;
 }

--- a/performance_test/src/communication_abstractions/ecal_proto_communicator.hpp
+++ b/performance_test/src/communication_abstractions/ecal_proto_communicator.hpp
@@ -146,9 +146,10 @@ public:
   // subscriber callback function
   void on_receive(const DataType& data_)
   {
-    // read time and id out of the received buffer
     lock();
-    m_data = data_;
+    // read time and id out of the received message
+    m_data.set_time(data_.time());
+    m_data.set_id(data_.id());
     unlock();
     // signal update_subscription to process
     gSetEvent(m_event);
@@ -212,7 +213,8 @@ public:
   /// Returns the data received in bytes.
   std::size_t data_received()
   {
-    return num_received_samples() * sizeof(DataType);
+    // still not correct but better then sizeof(DataType)
+    return num_received_samples() * m_data.msg_array_size() * sizeof(google::protobuf::uint32);
   }
 
 private:

--- a/performance_test/src/communication_abstractions/ecal_proto_communicator.hpp
+++ b/performance_test/src/communication_abstractions/ecal_proto_communicator.hpp
@@ -212,10 +212,10 @@ private:
 
   void init_msg(DataType & msg, std::int64_t time)
   {
-    msg.clear_msg_array_size();
-    msg.set_msg_array_size(msg.msg_array_size());
-    // fill with 0
-    msg.mutable_array()->Resize(msg.msg_array_size(), 0);
+    // set array size and fill it with 0
+    msg.set_msg_array_size(msg.msg_array_size_e_MAX);
+    msg.mutable_array()->Resize(msg.msg_array_size_e_MAX, 0);
+    // set time and id
     msg.set_time(time);
     msg.set_id(next_sample_id());
     ensure_fixed_size(msg);

--- a/performance_test/src/communication_abstractions/ecal_raw_communicator.hpp
+++ b/performance_test/src/communication_abstractions/ecal_raw_communicator.hpp
@@ -145,7 +145,9 @@ public:
   void on_receive(const struct eCAL::SReceiveCallbackData* data_)
   {
     // read time and id out of the received buffer
+    lock();
     m_data = std::move(*(static_cast<DataType*>(data_->buf)));
+    unlock();
     // signal update_subscription to process
     gSetEvent(m_event);
   }

--- a/performance_test/src/communication_abstractions/ecal_raw_communicator.hpp
+++ b/performance_test/src/communication_abstractions/ecal_raw_communicator.hpp
@@ -146,7 +146,9 @@ public:
   {
     // read time and id out of the received buffer
     lock();
-    m_data = std::move(*(static_cast<DataType*>(data_->buf)));
+    DataType* data_type_ptr = static_cast<DataType*>(data_->buf);
+    m_data.time = data_type_ptr->time;
+    m_data.id   = data_type_ptr->id;
     unlock();
     // signal update_subscription to process
     gSetEvent(m_event);


### PR DESCRIPTION
Both callback variants still make a memory copy inside the callback. This needs to get optimized next.